### PR TITLE
feat/links match new accessibility needs 

### DIFF
--- a/src/lib/markdown-renderer/styles.module.css
+++ b/src/lib/markdown-renderer/styles.module.css
@@ -51,7 +51,12 @@ table .code {
 }
 
 .blockquote a{
-  color: #D4084C !important;
+  color: #e31c58 !important;
+  text-decoration: underline 1px solid;
+}
+
+.blockquote a:hover{
+  color: #c81e51;
 }
 
 .blockquoteInfo {


### PR DESCRIPTION
### Description

Markdown rendered links now are underlined.
Links color now matchs vtex brading
Hover effect to markdown links

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
