### PR TITLE
fix(markdown-renderer): render callout icons as inline SVG instead of external asset

### DIFF
--- a/src/lib/markdown-renderer/Callout.stories.tsx
+++ b/src/lib/markdown-renderer/Callout.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { ThemeProvider } from '@vtex/brand-ui'
+import { Callout } from './components'
+
+const meta = {
+  title: 'Example/MarkdownRenderer/Callout',
+  component: Callout,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <ThemeProvider>
+        <Story />
+      </ThemeProvider>
+    ),
+  ],
+} satisfies Meta<typeof Callout>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Info: Story = {
+  args: {
+    node: {},
+    icon: 'info',
+    children: 'This is an info callout.',
+  },
+}
+
+export const Warning: Story = {
+  args: {
+    node: {},
+    icon: 'warning',
+    children: 'This is a warning callout.',
+  },
+}
+
+export const Danger: Story = {
+  args: {
+    node: {},
+    icon: 'danger',
+    children: 'This is a danger callout.',
+  },
+}
+
+export const Success: Story = {
+  args: {
+    node: {},
+    icon: 'success',
+    children: 'This is a success callout.',
+  },
+}

--- a/src/lib/markdown-renderer/components.tsx
+++ b/src/lib/markdown-renderer/components.tsx
@@ -56,7 +56,46 @@ const ObservableHeading = ({
   )
 }
 
-const Callout = ({ node, icon, ...props }: Component) => {
+const calloutColors: Record<string, string> = {
+  info: '#8C929D',
+  danger: '#DC5A41',
+  warning: '#FFB100',
+  success: '#80BE80',
+}
+
+const CalloutIcon = ({ type }: { type: string }) => (
+  <svg
+    className={styles.blockquoteIcon}
+    width="20"
+    height="20"
+    viewBox="0 0 20 20"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <circle cx="10" cy="10" r="10" fill={calloutColors[type] ?? calloutColors.info} />
+    {type === 'success' ? (
+      <path
+        d="M5.5 10.3L8.3 13L14.5 6.8"
+        stroke="white"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    ) : type === 'info' ? (
+      <>
+        <rect x="9.1" y="5" width="1.8" height="1.8" rx="0.9" fill="white" />
+        <rect x="9.1" y="8.2" width="1.8" height="6.8" rx="0.9" fill="white" />
+      </>
+    ) : (
+      <>
+        <rect x="9.1" y="5" width="1.8" height="7" rx="0.9" fill="white" />
+        <rect x="9.1" y="13.5" width="1.8" height="1.8" rx="0.9" fill="white" />
+      </>
+    )}
+  </svg>
+)
+
+export const Callout = ({ node, icon, ...props }: Component) => {
   const blockquoteType: string = icon ? icon : 'info'
   return (
     <blockquote
@@ -72,6 +111,7 @@ const Callout = ({ node, icon, ...props }: Component) => {
           : ''
       }`}
     >
+      <CalloutIcon type={blockquoteType} />
       <div {...props} />
     </blockquote>
   )

--- a/src/lib/markdown-renderer/styles.module.css
+++ b/src/lib/markdown-renderer/styles.module.css
@@ -75,34 +75,20 @@ table .code {
   color: #c81e51;
 }
 
+.blockquoteIcon {
+  display: inline-block;
+  flex-shrink: 0;
+  grid-row: 1;
+}
+
 .blockquoteInfo {
   background: #f8f7fc;
   border: 1px solid #ccced8;
 }
 
-.blockquoteInfo:before {
-  display: inline-block;
-  height: 20px;
-  width: 20px;
-  content: '';
-  background: url('https://vtex-dev-portal-navigation.fra1.digitaloceanspaces.com/info.svg')
-    no-repeat 0 0;
-  background-size: 20px 20px;
-}
-
 .blockquoteDanger {
   background: #fdefef;
   border: 1px solid #dc5a41;
-}
-
-.blockquoteDanger:before {
-  display: inline-block;
-  height: 20px;
-  width: 20px;
-  content: '';
-  background: url('https://vtex-dev-portal-navigation.fra1.digitaloceanspaces.com/danger.svg')
-    no-repeat 0 0;
-  background-size: 20px 20px;
 }
 
 .blockquoteWarning {
@@ -118,29 +104,9 @@ table .code {
   background-color: unset;
 }
 
-.blockquoteWarning:before {
-  display: inline-block;
-  height: 20px;
-  width: 20px;
-  content: '';
-  background: url('https://vtex-dev-portal-navigation.fra1.digitaloceanspaces.com/warning.svg')
-    no-repeat 0 0;
-  background-size: 20px 20px;
-}
-
 .blockquoteSuccess {
   background: #f3f8f3;
   border: 1px solid #80be80;
-}
-
-.blockquoteSuccess:before {
-  display: inline-block;
-  height: 20px;
-  width: 20px;
-  content: '';
-  background: url('https://vtex-dev-portal-navigation.fra1.digitaloceanspaces.com/success.svg')
-    no-repeat 0 0;
-  background-size: 20px 20px;
 }
 
 .flexWrap {


### PR DESCRIPTION
### Description

Callout/admonition icons (info, warning, danger, success) were loaded via a CSS `:before` `background-image` pointing at the DigitalOcean Space `vtex-dev-portal-navigation.fra1.digitaloceanspaces.com`. That bucket no longer exists (confirmed `404 NoSuchBucket` on all four icon URLs), so icons silently disappeared while the colored background/border still rendered fine — since those don't depend on an external resource.

This PR replaces the external image dependency with an inline SVG icon bundled directly in the `Callout` component, so rendering no longer depends on that (or any) external asset host.

Also added `Callout.stories.tsx` covering all four variants (`info`/`warning`/`danger`/`success`), since there was previously no direct Storybook coverage for this component — it was only reachable indirectly through the MDX pipeline.

<img width="1566" height="967" alt="image" src="https://github.com/user-attachments/assets/5f362554-50a2-46f8-a9fe-560dc63a15ac" />


#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

## Test plan

- [x] Verified in Storybook that all four callout variants (`Info`, `Warning`, `Danger`, `Success`) render their icons correctly with no network requests to the old bucket
- [x] Confirmed the `Warning` variant visually matches the expected design (orange circle with "!")